### PR TITLE
[9.0] improve the way crons are fetching files

### DIFF
--- a/sunatdb/controllers/main.py
+++ b/sunatdb/controllers/main.py
@@ -10,11 +10,10 @@ class SunatdbController(http.Controller):
 
     @http.route('/rfc', type='http', auth="public", methods=['GET'],
                 website=True)
-    def validate_email(self, token, user, rfc, **kwargs):
+    def validate_email(self, token, rfc, **kwargs):
 
         if request.env['res.users'].sudo().\
-                search([('login', '=', user),
-                        ('access_token', '=', token),
+                search([('access_token', '=', token),
                         ('authorized', '=', True)]):
             partner_data = request.env['res.partner'].sudo().\
                 search_read(domain=[('vat', '=', rfc)],

--- a/sunatdb/data/ir_cron.xml
+++ b/sunatdb/data/ir_cron.xml
@@ -9,17 +9,25 @@
             <field name="interval_type">days</field>
             <field name="numbercall">-1</field>
             <field name="nextcall" eval="(DateTime.now() + timedelta(days=2)).strftime('%Y-%m-%d %H:%M:%S')" />
-            <field eval="False" name="doall" />
-            <field eval="'res.partner'" name="model" />
-            <field eval="'_download_ruc_from_sunat'" name="function"/>
-            <field eval="'()'" name="args"/>
+            <field name="doall" eval="False"/>
+            <field name="model" eval="'res.partner'"/>
+            <field name="function" eval="'_register_new_partners'"/>
+            <field name="args" eval="'()'"/>
             <field name="priority">5</field>
         </record>
-
-    <function
-        model="ir.cron"
-        name="method_direct_trigger"
-        eval="[[ref('ir_cron_create_new_partners_from_sunat')]]"/>
-
+        <record id="ir_cron_download_zip_from_sunat" model="ir.cron">
+            <field name="name">Downloads and stores padron from SUNAT</field>
+            <field name="active" eval="False"/>
+            <field name="user_id" ref="base.user_root" />
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="numbercall">-1</field>
+            <field name="nextcall" eval="(DateTime.now() + timedelta(days=2)).strftime('%Y-%m-%d %H:%M:%S')" />
+            <field name="doall" eval="False"/>
+            <field name="model" eval="'res.partner'"/>
+            <field name="function" eval="'_download_zip_from_sunat'"/>
+            <field name="args" eval="'()'"/>
+            <field name="priority">5</field>
+        </record>
     </data>
 </openerp>

--- a/sunatdb/model/__init__.py
+++ b/sunatdb/model/__init__.py
@@ -26,3 +26,4 @@
 ##
 from . import res_partner
 from . import res_users
+from . import attachment

--- a/sunatdb/model/attachment.py
+++ b/sunatdb/model/attachment.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Vauxoo
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import models
+from openerp import fields
+
+
+class IrsAttachment(models.Model):
+    _inherit = 'ir.attachment'
+
+    db_check_update = fields.Boolean("SUNAT Padron check update",
+                                     default=False, copy=False)
+    db_zip = fields.Binary(string="File to store the SUNAT RUC database")

--- a/sunatdb/model/res_users.py
+++ b/sunatdb/model/res_users.py
@@ -58,21 +58,19 @@ class ResUsers(models.Model):
                                 'to do request')
 
     @api.multi
-    def random_token(self, i=0):
+    def random_token(self):
         """ Generates an ID to identify each one of record created
         return the strgin with record ID
         """
         self.ensure_one()
         # the token has an entropy of about 120 bits (6 bits/char * 20 chars)
         token = hashlib.sha256('%s-%s-%s' % (
-            datetime.now().replace(hour=i, minute=0, second=0, microsecond=0),
+            datetime.now().replace(hour=0, minute=0, second=0, microsecond=0),
             self.id,
             self.login)).hexdigest()
         if self.sudo().search([('access_token', '=', token)]):
-            i += 1
-            return self.random_token(i)
-        else:
-            return token
+            return self.random_token()
+        return token
 
     @api.one
     def generate_sunat_token(self):


### PR DESCRIPTION
There are several issues right now in this PR:

1. The way we retrieve the zip from sunat is not the best, urllib is taking so much time to retrieve a small dummy file that I doubt that the cron will ever do any job at all before a timeout

2. One cron to do all the work is not the best, we should retrieve the file one time and in another non related time process it's data

3. The method that retrieves the zip shall be configurable by URL in the method, otherwise we will need (in the event of the change of URL by sunat) to change that said URL each time.

4. We need a .travis.yml in this little app with the postgresql that we know works well

### urllib is no good

[![](http://img.youtube.com/vi/mBujP-9ZcmA/maxresdefault.jpg)](https://youtu.be/mBujP-9ZcmA "Soy un vidio :smile_cat: Danos manito arriba, comparte y suscribete y pasalo por whats ;)  ")


